### PR TITLE
feat: sp-allowed-dataset

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -8,6 +8,7 @@ import (
 	"github.com/application-research/delta-dm/util"
 	"github.com/jszwec/csvutil"
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 func ConfigureDatasetsRouter(e *echo.Group, dldm *core.DeltaDM) {
@@ -18,7 +19,9 @@ func ConfigureDatasetsRouter(e *echo.Group, dldm *core.DeltaDM) {
 	datasets.GET("", func(c echo.Context) error {
 		var ds []core.Dataset
 
-		dldm.DB.Model(&core.Dataset{}).Preload("Wallet").Find(&ds)
+		dldm.DB.Preload("Wallet").Preload("AllowedProviders", func(db *gorm.DB) *gorm.DB {
+			return db.Select("actor_id")
+		}).Find(&ds)
 
 		// Find  # of bytes total and replicated for each dataset
 		for i, d := range ds {

--- a/api/providers.go
+++ b/api/providers.go
@@ -88,18 +88,21 @@ func ConfigureProvidersRouter(e *echo.Group, dldm *core.DeltaDM) {
 			existing.AllowSelfService = false
 		}
 
-		var newAllowedDatasets []core.Dataset
-		for _, ds_name := range p.AllowedDatasets {
-			var ds core.Dataset
-			res := dldm.DB.Model(&core.Dataset{}).Where("name = ?", ds_name).First(&ds)
-			if res.Error != nil {
-				return fmt.Errorf("error fetching dataset %s : %s", ds_name, res.Error)
-			} else {
-				newAllowedDatasets = append(newAllowedDatasets, ds)
+		// If array of allowed datasets is empty, don't modify the association
+		if len(p.AllowedDatasets) > 0 {
+			var newAllowedDatasets []core.Dataset
+			for _, ds_name := range p.AllowedDatasets {
+				var ds core.Dataset
+				res := dldm.DB.Model(&core.Dataset{}).Where("name = ?", ds_name).First(&ds)
+				if res.Error != nil {
+					return fmt.Errorf("error fetching dataset %s : %s", ds_name, res.Error)
+				} else {
+					newAllowedDatasets = append(newAllowedDatasets, ds)
+				}
 			}
-		}
 
-		dldm.DB.Model(&existing).Association("AllowedDatasets").Replace(newAllowedDatasets)
+			dldm.DB.Model(&existing).Association("AllowedDatasets").Replace(newAllowedDatasets)
+		}
 
 		res = dldm.DB.Save(&existing)
 		if res.Error != nil {

--- a/api/providers.go
+++ b/api/providers.go
@@ -11,8 +11,9 @@ import (
 )
 
 type ProviderPutBody struct {
-	ActorName        string `json:"actor_name"`
-	AllowSelfService string `json:"allow_self_service"`
+	ActorName        string   `json:"actor_name"`
+	AllowSelfService string   `json:"allow_self_service"`
+	AllowedDatasets  []string `json:"allowed_datasets"`
 }
 
 func ConfigureProvidersRouter(e *echo.Group, dldm *core.DeltaDM) {
@@ -23,7 +24,7 @@ func ConfigureProvidersRouter(e *echo.Group, dldm *core.DeltaDM) {
 	providers.GET("", func(c echo.Context) error {
 		var p []core.Provider
 
-		dldm.DB.Find(&p)
+		dldm.DB.Preload("AllowedDatasets").Find(&p)
 
 		for i, sp := range p {
 			var rb [2]uint64
@@ -86,6 +87,19 @@ func ConfigureProvidersRouter(e *echo.Group, dldm *core.DeltaDM) {
 		} else if p.AllowSelfService == "off" {
 			existing.AllowSelfService = false
 		}
+
+		var newAllowedDatasets []core.Dataset
+		for _, ds_name := range p.AllowedDatasets {
+			var ds core.Dataset
+			res := dldm.DB.Model(&core.Dataset{}).Where("name = ?", ds_name).First(&ds)
+			if res.Error != nil {
+				return fmt.Errorf("error fetching dataset %s : %s", ds_name, res.Error)
+			} else {
+				newAllowedDatasets = append(newAllowedDatasets, ds)
+			}
+		}
+
+		dldm.DB.Model(&existing).Association("AllowedDatasets").Replace(newAllowedDatasets)
 
 		res = dldm.DB.Save(&existing)
 		if res.Error != nil {

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -14,6 +14,7 @@ func ProviderCmd() []*cli.Command {
 	var spId string
 	var spName string
 	var allowSelfService string
+	var allowedDatasets cli.StringSlice
 
 	// add a command to run API node
 	var providerCmds []*cli.Command
@@ -89,6 +90,11 @@ func ProviderCmd() []*cli.Command {
 						Usage:       "enable self-service for provider (on|off)",
 						Destination: &allowSelfService,
 					},
+					&cli.StringSliceFlag{
+						Name:        "allowed-datasets",
+						Usage:       "datasets the provider is permitted to replicate (comma separated list)",
+						Destination: &allowedDatasets,
+					},
 				},
 				Action: func(c *cli.Context) error {
 					cmd, err := NewCmdProcessor(c)
@@ -105,6 +111,7 @@ func ProviderCmd() []*cli.Command {
 					body := api.ProviderPutBody{
 						ActorName:        spName,
 						AllowSelfService: allowSelfService,
+						AllowedDatasets:  allowedDatasets.Value(),
 					}
 
 					b, err := json.Marshal(body)

--- a/core/database.go
+++ b/core/database.go
@@ -73,7 +73,7 @@ type Provider struct {
 	AllowSelfService bool          `json:"allow_self_service,omitempty" gorm:"notnull,default:true"`
 	BytesReplicated  ByteSizes     `json:"bytes_replicated,omitempty" gorm:"-"`
 	Replications     []Replication `json:"replications,omitempty" gorm:"foreignKey:ProviderActorID"`
-	AllowedDatasets  []Dataset     `json:"allowed_datasets,omitempty" gorm:"many2many:provider_allowed_datasets;"`
+	AllowedDatasets  []Dataset     `json:"allowed_datasets" gorm:"many2many:provider_allowed_datasets;"`
 }
 
 type ProviderAllowedDatasets struct {

--- a/docs/api.md
+++ b/docs/api.md
@@ -212,22 +212,50 @@ All endpoints (with the exception of `/self-service`) require the `Authorization
 #### Body
 ```jsonc
 [
-	{
+{
 		"key": "b3cc8a99-155a-4fff-8974-999ec313e5cc",
-		"actor_id": "f01963614",
+		"actor_id": "f0123456",
+		"actor_name": "jason",
+		"allow_self_service": false,
 		"bytes_replicated": {
-			"raw": 216120230655,
-			"padded": 412316860416
+			"raw": 234130249877,
+			"padded": 446676598784
 		},
+		"allowed_datasets": [
+			{
+				"ID": 1,
+				"CreatedAt": "2023-02-28T13:50:15.591038-08:00",
+				"UpdatedAt": "2023-02-28T13:50:23.928193-08:00",
+				"DeletedAt": null,
+				"name": "delta-test",
+				"replication_quota": 6,
+				"deal_duration": 540,
+				"unsealed": false,
+				"indexed": true,
+				"contents": null,
+				"bytes_replicated": {
+					"raw": 0,
+					"padded": 0
+				},
+				"bytes_total": {
+					"raw": 0,
+					"padded": 0
+				},
+				"allowed_providers": null
+			}
+		]
 	},
 	{
 		"key": "29c0c1ce-6b13-434c-8b94-49ba5a21b7a9",
-		"actor_id": "f01886797",
+		"actor_id": "f0998272",
+		"actor_name": "test sp",
+		"allow_self_service": true,
+		"allowed_datasets": [],
 		"bytes_replicated": {
 			"raw": 0,
 			"padded": 0
-		},
-	}
+		}
+	},
 ]
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -194,6 +194,7 @@ All endpoints (with the exception of `/self-service`) require the `Authorization
 {
 	actor_name: "Friendly name" // optional - friendly sp name 
 	allow_self_service: "on" // allow self-service replications ("on" or "off")
+	allowed_datasets: ["delta-test", "delta-test-2"] // list of datasets allowed to be replicated by this SP
 }
 ```
 

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -59,11 +59,11 @@ Example:
 ```
 
 ### Modify a provider
-`> ./delta-dm provider modify --id <sp-actor-id> [--name <friendly-name>] [--allow-self-service <on|off>]`
+`> ./delta-dm provider modify --id <sp-actor-id> [--name <friendly-name>] [--allowed-datasets <datasets>] [--allow-self-service <on|off>] `
 
 Example:
 ```bash
-./delta-dm provider modify --id f01000 --name "My Provider" --allow-self-service on
+./delta-dm provider modify --id f01000 --name "My Provider" --allowed-datasets delta-test,delta-test-2 --allow-self-service on
 ```
 
 ### List providers


### PR DESCRIPTION
Provides a method to restrict SP's to only be allowed to replicate certain datasets

- When a new provider is added, it's not allowed to replicate any datasets by default
- Allowed dataset list may be updated by calling the PUT `/providers` endpoint, and passing in `allowed_datasets` string array in the body
- GET `/providers` endpoint now includes the list of `allowed_datasets` in the response
- Allowed datasets affects both self-service deals, as well as calls to the `/replications` API - it will limit which content may be dealt out, regardless of if the `dataset` is specified in the request

Misc. updates in this PR:
- cleaned up the Replications `findUnreplicatedContentForProvider` query
- Return an error message if there's no content to be replicated to the provider 