### PR TITLE
feat: allow specifying delay start in replications body

### DIFF
--- a/api/selfservice.go
+++ b/api/selfservice.go
@@ -57,7 +57,7 @@ func selfServiceTokenMiddleware(dldm *core.DeltaDM) echo.MiddlewareFunc {
 func handleSelfServiceByCid(c echo.Context, dldm *core.DeltaDM) error {
 	piece := c.Param("piece")
 	startEpochDelay := c.QueryParam("start_epoch_delay")
-	var delayDays uint64 = 3
+	var delayDays uint64 = DEFAULT_DELAY_DAYS
 
 	if startEpochDelay != "" {
 		var err error

--- a/cmd/replication.go
+++ b/cmd/replication.go
@@ -13,6 +13,7 @@ func ReplicationCmd() []*cli.Command {
 	var num uint
 	var provider string
 	var dataset string
+	var delayStartDays uint64
 
 	// add a command to run API node
 	var replicationCmds []*cli.Command
@@ -43,6 +44,11 @@ func ReplicationCmd() []*cli.Command {
 						Usage:       "dataset to replicate",
 						Destination: &dataset,
 					},
+					&cli.Uint64Flag{
+						Name:        "delay-start",
+						Usage:       "number of days to delay start of deal",
+						Destination: &delayStartDays,
+					},
 				},
 				Action: func(c *cli.Context) error {
 					cmd, err := NewCmdProcessor(c)
@@ -57,6 +63,10 @@ func ReplicationCmd() []*cli.Command {
 
 					if dataset != "" {
 						body.Dataset = &dataset
+					}
+
+					if delayStartDays != 0 {
+						body.DelayStartDays = &delayStartDays
 					}
 
 					b, err := json.Marshal(body)

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,8 @@ baga6ea4seaqhf2ymr6ahkxe3i2txmnqbmltzyf65nwcdvq2hvwmcx4eu4wzl4fi,bafybeif2bu5bdq
 {
   provider: "f01234", // required! ID of the SP to create deals with
   dataset: "test-dataset", // optional - if unspecified, will select content from any dataset
-  numDeals: 10, // optional - if unspecified, then numTib must be specified. Number of deals to make
+  num_deals: 10, // Number of deals to make
+	delay_start_days: 3 // Optional - delay start of deals by this many days. Default is 3. Must be between 1 and 14.
 }
 ```
 

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -83,11 +83,11 @@ Example:
 
 ## replication
 ### Create a replication
-`> ./delta-dm replication create --provider <sp-actor-id> -num <num-deals-to-make> [--dataset <dataset-name>]`
+`> ./delta-dm replication create --provider <sp-actor-id> -num <num-deals-to-make> [--dataset <dataset-name>] [--delay-start <delay-start-days>]`
 
 Example:
 ```bash
-./delta-dm replication create --provider f01000 --num 3 --dataset delta-test
+./delta-dm replication create --provider f01000 --num 3 --dataset delta-test --delay-start 3
 ```
 
 ## content


### PR DESCRIPTION
- User can now provide `delay_start_days` in the body of the replication request to delay the start epoch of the deal. Will default to 3 if unspecified. 