### PR TITLE
feat: secure api key

### DIFF
--- a/core/database.go
+++ b/core/database.go
@@ -46,7 +46,7 @@ func OpenDatabase(dbDsn string, debug bool) (*gorm.DB, error) {
 }
 
 func ConfigureModels(db *gorm.DB) {
-	err := db.AutoMigrate(&Replication{}, &Provider{}, &Dataset{}, &Content{}, &Wallet{}, &ProviderAllowedDatasets{}, &WalletDatasets{})
+	err := db.AutoMigrate(&Replication{}, &Provider{}, &Dataset{}, &Content{}, &Wallet{}, &ProviderAllowedDatasets{}, &WalletDatasets{}, &Auth{})
 
 	if err != nil {
 		log.Fatalf("error migrating database: %s", err)
@@ -60,6 +60,10 @@ const (
 	StatusSuccess ReplicationStatus = "SUCCESS"
 	StatusFailure ReplicationStatus = "FAILURE"
 )
+
+type Auth struct {
+	AuthToken string `json:"auth_token" gorm:"primaryKey"`
+}
 
 // A replication refers to a deal, for a specific content, with a client
 type Replication struct {

--- a/core/database.go
+++ b/core/database.go
@@ -46,7 +46,7 @@ func OpenDatabase(dbDsn string, debug bool) (*gorm.DB, error) {
 }
 
 func ConfigureModels(db *gorm.DB) {
-	err := db.AutoMigrate(&Replication{}, &Provider{}, &Dataset{}, &Content{}, &Wallet{}, &ProviderAllowedDatasets{}, &WalletDatasets{}, &Auth{})
+	err := db.AutoMigrate(&Replication{}, &Provider{}, &Dataset{}, &Content{}, &Wallet{}, &ProviderAllowedDatasets{}, &WalletDatasets{})
 
 	if err != nil {
 		log.Fatalf("error migrating database: %s", err)
@@ -60,10 +60,6 @@ const (
 	StatusSuccess ReplicationStatus = "SUCCESS"
 	StatusFailure ReplicationStatus = "FAILURE"
 )
-
-type Auth struct {
-	AuthToken string `json:"auth_token" gorm:"primaryKey"`
-}
 
 // A replication refers to a deal, for a specific content, with a client
 type Replication struct {

--- a/core/ldm.go
+++ b/core/ldm.go
@@ -36,7 +36,7 @@ func NewDeltaDM(dbConnStr string, deltaApi string, authToken string, authServerU
 		log.Debugf("successfully connected to api at %s\n", deltaApi)
 	}
 
-	as := NewAuthServer(authServerUrl)
+	as := NewAuthServer(authServerUrl, db)
 
 	return &DeltaDM{
 		DAPI:       dapi,

--- a/core/ldm.go
+++ b/core/ldm.go
@@ -36,7 +36,7 @@ func NewDeltaDM(dbConnStr string, deltaApi string, authToken string, authServerU
 		log.Debugf("successfully connected to api at %s\n", deltaApi)
 	}
 
-	as := NewAuthServer(authServerUrl, db)
+	as := NewAuthServer(authServerUrl, authToken)
 
 	return &DeltaDM{
 		DAPI:       dapi,

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,7 +5,7 @@ All endpoints are prefixed with `/api/v1`.
 
 For example, `http://localhost:1314/api/v1/datasets`
 
-All endpoints (with the exception of `/self-service`) require the `Authorization: Bearer <XXX>` header present on the request. Set this to the Delta API key.
+All endpoints (with the exception of `/self-service`) require the `Authorization: Bearer <XXX>` header present on the request. It must match the `Delta API Key` that is passed into `delta-dm daemon` in order to be permitted to make requests.
 
 ## /health
 


### PR DESCRIPTION
API key provided to incoming requests must now match the key that is used to configure delta-dm when it's started.

This prevents unauthorized keys from being used to access DDM.