### PR TITLE
fix: explicity specify gorm Scan struct

### DIFF
--- a/api/replications.go
+++ b/api/replications.go
@@ -274,8 +274,8 @@ func handlePostReplications(c echo.Context, dldm *core.DeltaDM) error {
 			ConnectionMode:     "import",
 			Miner:              d.Provider,
 			Size:               c.Size,
-			SkipIpniAnnounce:   !c.ReplicationProfile.Indexed,
-			RemoveUnsealedCopy: !c.ReplicationProfile.Unsealed,
+			SkipIpniAnnounce:   !c.Indexed,
+			RemoveUnsealedCopy: !c.Unsealed,
 			DurationInDays:     c.DealDuration,
 			StartEpochInDays:   delayStartEpoch,
 			PieceCommitment: core.PieceCommitment{
@@ -296,10 +296,10 @@ func handlePostReplications(c echo.Context, dldm *core.DeltaDM) error {
 type replicatedContentQueryResponse struct {
 	db.Content
 	db.Dataset
-	ReplicationProfile struct {
-		db.ReplicationProfile
-		DatasetID struct{} // prevent the ambiguous selector - we already have this coming from the `db.Dataset` model
-	}
+	// Note: We can't use `db.ReplicationProfile` here because it has a `DatasetID` field which conflicts with the `Dataset` field above
+	// Thus, Unsealed and Indexed are added manually
+	Unsealed bool
+	Indexed  bool
 }
 
 // Query the database for all contant that does not have replications to this actor yet

--- a/api/selfservice.go
+++ b/api/selfservice.go
@@ -232,8 +232,8 @@ func handleSelfServiceByDataset(c echo.Context, dldm *core.DeltaDM) error {
 		ConnectionMode:     "import",
 		Miner:              p.ActorID,
 		Size:               deal.Size,
-		SkipIpniAnnounce:   !deal.ReplicationProfile.Indexed,
-		RemoveUnsealedCopy: !deal.ReplicationProfile.Unsealed,
+		SkipIpniAnnounce:   !deal.Indexed,
+		RemoveUnsealedCopy: !deal.Unsealed,
 		DurationInDays:     deal.DealDuration - delayDays,
 		StartEpochInDays:   delayDays,
 		PieceCommitment: core.PieceCommitment{


### PR DESCRIPTION
Fixes the Gorm unmarshalling logic for Replication Profiles when determining unsealed/indexed flags